### PR TITLE
Userモデルにバリデーションの追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :nickname, presence: true
 end


### PR DESCRIPTION
#What
deviseを用いたユーザー登録機能実装の際に、追加したniknameカラムに対してバリデーションを追加した。

#Why
nicknameが空のまま登録されるのを防ぐため。