### PR TITLE
新規会員登録ページの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ gem "haml-rails"
 gem "font-awesome-sass"
 gem "carrierwave"
 gem "mini_magick"
+gem 'fog-aws'
 gem "devise"
 gem 'payjp'
 gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,10 +116,28 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
+    excon (0.73.0)
     execjs (2.7.0)
     ffi (1.12.2)
+    fog-aws (3.6.3)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.0)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-sass (5.12.0)
       sassc (>= 1.11)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -145,6 +163,7 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     io-like (0.3.1)
+    ipaddress (0.8.3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jquery-rails (4.3.5)
@@ -173,6 +192,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    multi_json (1.14.1)
     mysql2 (0.5.3)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -320,6 +340,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  fog-aws
   font-awesome-sass
   haml-rails
   jbuilder (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Flea Market app
 
 - has_one :identification
 - has_many :goods
-- has_many :deliveryAddresses
+- has_one :deliveryAddresses
 - has_many :creditCards
 
 ## identifications Table
@@ -55,11 +55,7 @@ Flea Market app
 | firstName      | string  | null: false       |
 | familyNameKana | string  | null: false       |
 | firstNameKana  | string  | null: false       |
-| birthYear      | date    | null: false       |
-| birthMonth     | date    | null: false       |
 | birthDay       | date    | null: false       |
-| userImage      | string  |                   |
-| introduction   | text    |                   |
 
 ### Association
 
@@ -89,7 +85,7 @@ Flea Market app
 | familyNameKana | string  | null: false                    |
 | firstNameKana  | string  | null: false                    |
 | postCode       | integer | null: false                    |
-| prefecture     | string  | null: false                    |
+| prefecture_id  | integer | null: false                    |
 | city           | string  | null: false                    |
 | address        | string  | null: false                    |
 | buildingName   | string  |                                |

--- a/app/assets/stylesheets/config/colors.scss
+++ b/app/assets/stylesheets/config/colors.scss
@@ -1,4 +1,5 @@
 $white: #fff;
 $furimaColor: #3ccace;
-$lightGray: #f5f5f5;
+$smoke: #f5f5f5;
 $borderFocus: #0095ee;
+$lightGray: #ccc;

--- a/app/assets/stylesheets/mixin/_dropDown.scss
+++ b/app/assets/stylesheets/mixin/_dropDown.scss
@@ -1,0 +1,8 @@
+@mixin dropDown {
+  .fa-chevron-down {
+    position: absolute;
+    right: 20px;
+    top: 33px;
+    color: #888888;
+  }
+}

--- a/app/assets/stylesheets/mixin/_mustMark.scss
+++ b/app/assets/stylesheets/mixin/_mustMark.scss
@@ -4,6 +4,6 @@
   font-size: 12px;
   font-weight: 600;
   border-radius: 2px;
-  padding: 2px 4px;
+  padding: 3px 4px;
   margin-left: 3px;
 }

--- a/app/assets/stylesheets/mixin/_optionMark.scss
+++ b/app/assets/stylesheets/mixin/_optionMark.scss
@@ -4,6 +4,6 @@
   font-size: 12px;
   font-weight: 600;
   border-radius: 2px;
-  padding: 2px 4px;
+  padding: 3px 4px;
   margin-left: 3px;
 }

--- a/app/assets/stylesheets/mixin/_registForm.scss
+++ b/app/assets/stylesheets/mixin/_registForm.scss
@@ -1,0 +1,10 @@
+@mixin registForm {
+  height: 48px;
+  margin-top: 8px;
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 0 15px;
+  border-radius: 4px;
+  border: 1px solid $lightGray;
+  background: $white;
+}

--- a/app/assets/stylesheets/mixin/_selectForm.scss
+++ b/app/assets/stylesheets/mixin/_selectForm.scss
@@ -4,4 +4,10 @@
   height: 48px;
   outline: none;
   background-color: #ffffff;
+  padding: 0 16px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  border: 1px solid #ccc;
 }

--- a/app/assets/stylesheets/modules/_registrations.scss
+++ b/app/assets/stylesheets/modules/_registrations.scss
@@ -47,6 +47,17 @@
         border-radius: 4px;
         border: 1px solid #ccc;
         background: $white;
+        &--half {
+          width: 48%;
+          height: 48px;
+          margin-top: 8px;
+          font-size: 16px;
+          line-height: 1.5;
+          padding: 0 15px;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          background: $white;
+        }
       }
     }
     &__submit {
@@ -61,4 +72,13 @@
       }
     }
   }
+}
+
+#identification_birthday_1i, #identification_birthday_2i, #identification_birthday_3i {
+  font-size: 20px;
+  margin-top: 8px;
+  background-color: $white;
+  border: 1px solid #ccc;
+  height: 48px;
+  width: 27%;
 }

--- a/app/assets/stylesheets/modules/_users.scss
+++ b/app/assets/stylesheets/modules/_users.scss
@@ -1,1 +1,1 @@
-@import 'registrationsUsers';
+@import 'registrations';

--- a/app/assets/stylesheets/modules/_users.scss
+++ b/app/assets/stylesheets/modules/_users.scss
@@ -1,1 +1,1 @@
-@import 'registrations';
+@import 'users/registrations';

--- a/app/assets/stylesheets/modules/_users.scss
+++ b/app/assets/stylesheets/modules/_users.scss
@@ -1,1 +1,2 @@
 @import 'users/registrations';
+@import "goods/new";

--- a/app/assets/stylesheets/modules/goods/_new.scss
+++ b/app/assets/stylesheets/modules/goods/_new.scss
@@ -4,6 +4,7 @@
 @import "mixin/selectForm";
 @import "mixin/textField";
 @import "mixin/footerSub";
+@import "mixin/dropDown";
 
 .goodsNew {
   width: 100%;
@@ -65,6 +66,7 @@
             height: 150px;
             border: 1px dashed #cccccc;
             background-color: #f5f5f5;
+            cursor: pointer;
 
             &--form {
               display: none;
@@ -149,13 +151,21 @@
           }
         }
 
-        #good_category_id {
-          @include selectForm;
+        .selectBox {
+          display: flex;
+          position: relative;
+
+          #good_category_id {
+            @include selectForm;
+          }
+
+          #good_category_id:focus {
+            border-color: $borderFocus;
+          }
+
+          @include dropDown;
         }
 
-        #good_category_id:focus {
-          border-color: $borderFocus;
-        }
 
         .detail__brand {
           margin-top: 32px;
@@ -189,12 +199,19 @@
           }
         }
 
-        #good_goodsCondition {
-          @include selectForm;
-        }
+        .selectBox {
+          display: flex;
+          position: relative;
 
-        #good_goodsCondition:focus {
-          border-color: $borderFocus;
+          #good_goodsCondition {
+            @include selectForm;
+          }
+
+          #good_goodsCondition:focus {
+            border-color: $borderFocus;
+          }
+
+          @include dropDown;
         }
       }
 
@@ -214,13 +231,21 @@
           }
         }
 
-        #good_deliveryFee {
-          @include selectForm;
+        .selectBox {
+          display: flex;
+          position: relative;
+
+          #good_deliveryFee {
+            @include selectForm;
+          }
+
+          #good_deliveryFee:focus {
+            border-color: $borderFocus;
+          }
+
+          @include dropDown;
         }
 
-        #good_deliveryFee:focus {
-          border-color: $borderFocus;
-        }
 
         .delivery__prefecture {
           margin-top: 16px;
@@ -234,13 +259,21 @@
           }
         }
 
-        #good_prefecture_id {
-          @include selectForm;
+        .selectBox {
+          display: flex;
+          position: relative;
+
+          #good_prefecture_id {
+            @include selectForm;
+          }
+
+          #good_prefecture_id:focus {
+            border-color: $borderFocus;
+          }
+
+          @include dropDown;
         }
 
-        #good_prefecture_id:focus {
-          border-color: $borderFocus;
-        }
 
         .delivery__day {
           margin-top: 16px;
@@ -254,13 +287,21 @@
           }
         }
 
-        #good_deliveryDay {
-          @include selectForm;
+        .selectBox {
+          display: flex;
+          position: relative;
+
+          #good_deliveryDay {
+            @include selectForm;
+          }
+
+          #good_deliveryDay:focus {
+            border-color: $borderFocus;
+          }
+
+          @include dropDown;
         }
 
-        #good_deliveryDay:focus {
-          border-color: $borderFocus;
-        }
       }
 
       .goodsNew__form__price {

--- a/app/assets/stylesheets/modules/goods/_show.scss
+++ b/app/assets/stylesheets/modules/goods/_show.scss
@@ -2,6 +2,7 @@
   width: 100%;
   height: 55px;
   border-top: 1px solid #eee;
+
   .asideCategoryBox {
     width: 100%;
     height: 53px;
@@ -16,25 +17,31 @@
         font-size: 14px;
         width: 680px;
         margin: 0 auto;
+
         .iconChevronRight {
           font-size: 5px;
         }
+
         .cateTop {
           text-decoration: none;
           color: #333333;
         }
+
         .cateCate {
           text-decoration: none;
           color: #333333;
         }
+
         .cateCateSub {
           text-decoration: none;
           color: #333333;
         }
+
         .cateCateSubSub {
           text-decoration: none;
           color: #333333;
         }
+
         .cateProductName {
           text-decoration: none;
           color: #333333;
@@ -49,16 +56,20 @@
   margin-top: 3px;
   background-color: #f8f7f7fa;
   width: 100%;
+
   &__showGoodsBody {
     height: 1770px;
     padding-top: 35px;
+
     &__showGoodsBodyMain {
       width: 700px;
       height: 1770px;
       color: black;
       margin: 0 auto;
+
       &__showGoodsBodyMainSelect {
         background-color: white;
+
         .selectItemName {
           margin: 0 auto;
 
@@ -69,33 +80,41 @@
           text-align: center;
           font-size: 17px;
         }
+
         .selectContent {
           margin: 0 auto;
           width: 620px;
           height: 400px;
           margin-bottom: 20px;
+
           &__selectContentPhotos {
             height: 400px;
+
             &__selectContentPhotosPhoto {
               height: 400px;
+
               &__selectContentPhotosPhotoOne {
                 width: auto;
                 height: 70%;
                 text-align: center;
-                .rony {
-                }
+
+                .rony {}
               }
+
               &__selectContentPhotosPhotoOther {
                 width: 560px;
                 height: 30%;
                 display: flex;
                 margin: 0 auto;
+
                 .rony {
                   width: 33%;
                 }
+
                 .ronyShoe {
                   width: 33%;
                 }
+
                 .ronyUniform {
                   width: 33%;
                 }
@@ -103,48 +122,56 @@
             }
           }
         }
+
         .selectPriceBox {
           margin-top: 15px;
           margin-bottom: 15px;
           text-align: center;
+
           &__selectPriceBoxMoney {
             margin: 0 auto;
             width: 610px;
             height: 55px;
+
             .iconYen {
               font-size: 38px;
             }
+
             .spanMoney {
               font-weight: bold;
               font-size: 38px;
             }
           }
+
           &__selectPriceBoxSupp {
             justify-content: center;
             width: 620px;
             height: 25px;
             margin-left: 40px;
+
             &__selectPriceBoxSuppTax {
-              .spanTax {
-              }
+              .spanTax {}
             }
+
             &__selectPriceBoxSuppShippingFee {
-              .spanShippingFee {
-              }
+              .spanShippingFee {}
             }
           }
         }
+
         .selectPurchace {
           width: 100%;
           text-align: center;
           font-weight: bold;
           margin: 0px 0px 10px 0px;
+
           &__selectPurchaceMove {
             margin: 0 auto;
             width: 90%;
             height: 60px;
             line-height: 60px;
             background-color: #3ccace;
+
             .selectPurchaceMoveForm {
               .selectPurchaceMoveFormBtn {
                 background-color: #3ccace;
@@ -154,16 +181,19 @@
             }
           }
         }
+
         .selectDescription {
           margin: 0 auto;
           width: 620px;
           height: 160px;
+
           &__selectDescriptionBody {
             .selectDescriptionBodyExplain {
               font-size: 17px;
             }
           }
         }
+
         .selectTables {
           &__selectTablesBody {
             table {
@@ -172,8 +202,9 @@
               border: solid 1px rgb(209, 207, 207);
               margin: 0 auto;
             }
-            table tr {
-            }
+
+            table tr {}
+
             table th {
               background-color: #eeeeee;
               width: 40%;
@@ -182,27 +213,33 @@
               font-size: 15px;
               padding: 13px 0px 13px 0px;
             }
+
             table td {
               width: 60%;
               padding: 13px 0px 13px 20px;
               border-color: rgb(209, 207, 207);
               font-size: 15px;
+
               .exhibitorName {
                 text-decoration: none;
                 color: black;
               }
+
               .exhibitionCategory {
                 color: #3ccace;
                 text-decoration: none;
               }
+
               .exhibitionCategorySub {
                 color: #3ccace;
                 text-decoration: none;
               }
+
               .exhibitionCategorySubSub {
                 color: #3ccace;
                 text-decoration: none;
               }
+
               .exhibitionAddress {
                 color: #3ccace;
                 text-decoration: none;
@@ -210,6 +247,7 @@
             }
           }
         }
+
         .selectReport {
           margin: 0 auto;
           width: 100%;
@@ -218,10 +256,12 @@
           margin-top: 20px;
           margin-bottom: 30px;
           display: inline-block;
+
           &__selectReportLeft {
             display: flex;
             justify-content: space-between;
             margin-left: 37px;
+
             &__selectReportLeftLike {
               .selectReportLeftLikeForm {
                 .selectReportLeftLikeBtn {
@@ -231,15 +271,16 @@
                   height: 37px;
                   font-size: 16px;
                   border-color: orange;
-                  .iconStar {
-                  }
-                  .spanStarWord {
-                  }
-                  .spanStarNumber {
-                  }
+
+                  .iconStar {}
+
+                  .spanStarWord {}
+
+                  .spanStarNumber {}
                 }
               }
             }
+
             &__selectReportLeftBad {
               margin-right: 37px;
 
@@ -251,10 +292,10 @@
                   border: 1px solid black;
                   padding: 10px 12px 10px 12px;
                   border-radius: 5px;
-                  .iconFlag {
-                  }
-                  .spanFlag {
-                  }
+
+                  .iconFlag {}
+
+                  .spanFlag {}
                 }
               }
             }
@@ -267,13 +308,16 @@
         background-color: white;
         width: 700px;
         height: 300px;
+
         &__showGoodsBodyMainCommentContent {
           .mainCommentContentBody {
             .mainCommentContentBodyForm {
               text-align: center;
+
               .mainCommentContentBodyTextarea {
                 margin-top: 25px;
               }
+
               .mainCommentContentBodyFormAttention {
                 background-color: #fcf9f9fa;
                 padding: 10px 0px 5px 10px;
@@ -282,6 +326,7 @@
                 width: 90%;
                 margin-left: 35px;
               }
+
               .mainCommentContentBodyTag {
                 background-color: #3ccace;
                 border-radius: 30px;
@@ -295,6 +340,7 @@
                   color: white;
                   font-size: 20px;
                 }
+
                 .mainCommentContentBodyTagBtn {
                   padding-top: 15px;
                   background-color: #3ccace;
@@ -308,33 +354,39 @@
           }
         }
       }
+
       &__showGoodsBodyMainOtherItem {
         width: 700px;
         height: 24px;
         color: #3ccace;
         margin-top: 10px;
         margin-bottom: 15px;
+
         &__showGoodsBodyMainOtherItemBox {
           .mainOtherItemBoxUl {
             display: flex;
             justify-content: space-between;
             line-height: 24px;
+
             .mainOtherItemBoxUlPrev {
               .iconChevronLeft {
                 padding-left: 10px;
               }
+
               .mainOtherItemBoxUlPrevOne {
                 text-decoration: none;
                 color: #3ccace;
                 font-size: 17px;
               }
             }
+
             .mainOtherItemBoxUlNext {
               .mainOtherItemBoxUlNextOne {
                 text-decoration: none;
                 color: #3ccace;
                 font-size: 17px;
               }
+
               .iconChevronRight {
                 padding-right: 10px;
               }
@@ -342,6 +394,7 @@
           }
         }
       }
+
       &__showGoodsBodyMainNavi {
         width: 700px;
         height: 33px;
@@ -349,6 +402,7 @@
         font-weight: bold;
         margin-top: 10px;
         margin-bottom: 10px;
+
         &__showGoodsBodyMainNaviBox {
           .naviBoxBrend {
             .naviBoxBrendTopUl {
@@ -372,11 +426,13 @@
   position: relative;
   width: 100%;
   height: 392px;
+
   .asideBannerPhoto {
     width: 100%;
     height: 100%;
     object-fit: cover;
   }
+
   .asideBannerIn {
     text-align: center;
     position: absolute;
@@ -385,6 +441,7 @@
     right: 0;
     bottom: 0;
     margin: 0 auto;
+
     .asideBannerInHead {
       font-weight: bold;
       color: white;
@@ -396,6 +453,7 @@
       white-space: nowrap;
       text-shadow: 1px 1px 5px grey;
     }
+
     .asideBannerInPhrase {
       color: white;
       font-size: 35px;
@@ -407,6 +465,7 @@
       text-shadow: 1px 1px 5px grey;
     }
   }
+
   .asideBannerAt {
     display: flex;
     position: absolute;
@@ -421,20 +480,25 @@
     .asideBannerAtApple {
       margin-right: 5px;
       margin-left: 5px;
+
       .appleBtn:hover {
         opacity: 0.6;
       }
+
       .appleBtn {
         width: 180px;
         height: 54px;
       }
     }
+
     .asideBannerAtGoogle {
       margin-right: 5px;
       margin-left: 5px;
+
       .googleBtn:hover {
         opacity: 0.6;
       }
+
       .googleBtn {
         width: 180px;
         height: 54px;
@@ -446,26 +510,32 @@
 .footer {
   width: 100%;
   height: 310px;
+
   &__footerContent {
     padding-top: 50px;
     padding-bottom: 50px;
     background-color: #272727;
     padding-left: 10px;
+
     &__footerContentBody {
       .ContentBodyUl {
         display: flex;
         justify-content: center;
         color: white;
+
         .footerContentUlLi {
           text-align: center;
           margin-right: 60px;
           margin-left: 60px;
+
           .footerContentUlLiHead {
             font-weight: bold;
             font-size: 15px;
           }
+
           .footerContentUlLiFoo {
             margin-top: 20px;
+
             .Lin {
               color: white;
               text-decoration: none;
@@ -476,13 +546,16 @@
         }
       }
     }
+
     &__footerContentBrand {
       text-align: center;
+
       &__footerContentBrandLogo {
         .logoImage {
           width: 160px;
           height: 45px;
         }
+
         .logoMark {
           color: white;
           font-size: 13px;
@@ -495,6 +568,7 @@
 .displayBtn:hover {
   opacity: 0.95;
 }
+
 .displayBtn {
   list-style: none;
   border-radius: 5px;
@@ -506,12 +580,14 @@
   background-color: #3ccace;
   text-align: center;
   padding-top: 15px;
+
   .displayWord {
     text-decoration: none;
     color: white;
     font-weight: bold;
     display: block;
   }
+
   .iconCamera {
     color: white;
     font-size: 60px;

--- a/app/assets/stylesheets/modules/users/_registrations.scss
+++ b/app/assets/stylesheets/modules/users/_registrations.scss
@@ -29,6 +29,27 @@
     margin: 0 auto;
     padding-bottom: 64px;
 
+    &__thankyou {
+      font-size: 18px;
+      text-align: center;
+      margin-top: 50px;
+    }
+
+    &__homelink {
+      margin-top: 50px;
+      text-align: center;
+      &__btn {
+        display: block;
+        border: 1px solid $furimaColor;
+        background-color: $furimaColor;
+        color: $white;
+        width: 100%;
+        line-height: 48px;
+        font-size: 14px;
+        text-align: center;
+      }
+    }
+
     &__formGroup {
       margin-top: 32px;
       width: 100%;

--- a/app/assets/stylesheets/modules/users/_registrations.scss
+++ b/app/assets/stylesheets/modules/users/_registrations.scss
@@ -7,6 +7,17 @@
   font-size: 14px;
 }
 
+.registerheader {
+  height: 128px;
+
+  &__logo {
+    text-align: center;
+    line-height: 128px;
+    position: relative;
+    top: 18px;
+  }
+}
+
 .registerWrapper {
   background-color: $white;
   width: 700px;

--- a/app/assets/stylesheets/modules/users/_registrations.scss
+++ b/app/assets/stylesheets/modules/users/_registrations.scss
@@ -28,15 +28,23 @@
       width: 100%;
       &__label {
         font-weight: 600;
+        &--must {
+          background-color: #ea352d;
+          color: $white;
+          margin-left: 8px;
+          padding: 2px 4px;
+          border-radius: 2px;
+          font-size: 12px;
+        }
+        &--optional {
+          background-color: #ccc;
+          color: $white;
+          margin-left: 8px;
+          padding: 2px 4px;
+          border-radius: 2px;
+          font-size: 12px;
+        }
       }
-    span {
-      background-color: #ea352d;
-      color: $white;
-      margin-left: 8px;
-      padding: 2px 4px;
-      border-radius: 2px;
-      font-size: 12px;
-    }
       &__form {
         width: 100%;
         height: 48px;

--- a/app/assets/stylesheets/modules/users/_registrations.scss
+++ b/app/assets/stylesheets/modules/users/_registrations.scss
@@ -45,6 +45,22 @@
           font-size: 12px;
         }
       }
+      #delivery_address_prefecture_id {
+        width: 100%;
+        background-color: $white;
+        font-size: 16px;
+        margin-top: 8px;
+        border: 1px solid #ccc;
+        height: 48px;
+      }
+      #identification_birthday_1i, #identification_birthday_2i, #identification_birthday_3i {
+        font-size: 20px;
+        margin-top: 8px;
+        background-color: $white;
+        border: 1px solid #ccc;
+        height: 48px;
+        width: 27%;
+      }
       &__form {
         width: 100%;
         height: 48px;
@@ -80,13 +96,4 @@
       }
     }
   }
-}
-
-#identification_birthday_1i, #identification_birthday_2i, #identification_birthday_3i {
-  font-size: 20px;
-  margin-top: 8px;
-  background-color: $white;
-  border: 1px solid #ccc;
-  height: 48px;
-  width: 27%;
 }

--- a/app/assets/stylesheets/modules/users/_registrations.scss
+++ b/app/assets/stylesheets/modules/users/_registrations.scss
@@ -1,7 +1,9 @@
+@import "mixin/registForm";
+
 .registerBody {
   width: 100%;
   height: 100%;
-  background-color: $lightGray;
+  background-color: $smoke;
   font-size: 14px;
 }
 
@@ -9,25 +11,31 @@
   background-color: $white;
   width: 700px;
   margin: 0 auto;
+
   &__head {
     height: 97px;
     line-height: 97px;
     text-align: center;
-    border-bottom: 1px solid $lightGray;
+    border-bottom: 1px solid $smoke;
+
     h2 {
       font-size: 22px;
       font-weight: bold;
     }
   }
+  
   &__content {
     width: 343px;
     margin: 0 auto;
     padding-bottom: 64px;
+
     &__formGroup {
       margin-top: 32px;
       width: 100%;
+
       &__label {
         font-weight: 600;
+
         &--must {
           background-color: #ea352d;
           color: $white;
@@ -36,8 +44,9 @@
           border-radius: 2px;
           font-size: 12px;
         }
+
         &--optional {
-          background-color: #ccc;
+          background-color: $lightGray;
           color: $white;
           margin-left: 8px;
           padding: 2px 4px;
@@ -45,47 +54,39 @@
           font-size: 12px;
         }
       }
+
       #delivery_address_prefecture_id {
         width: 100%;
         background-color: $white;
         font-size: 16px;
         margin-top: 8px;
-        border: 1px solid #ccc;
+        border: 1px solid $lightGray;
         height: 48px;
       }
+
       #identification_birthday_1i, #identification_birthday_2i, #identification_birthday_3i {
         font-size: 20px;
         margin-top: 8px;
         background-color: $white;
-        border: 1px solid #ccc;
+        border: 1px solid $lightGray;
         height: 48px;
         width: 27%;
       }
+
       &__form {
+        @include registForm;
         width: 100%;
-        height: 48px;
-        margin-top: 8px;
-        font-size: 16px;
-        line-height: 1.5;
-        padding: 0 15px;
-        border-radius: 4px;
-        border: 1px solid #ccc;
-        background: $white;
+
         &--half {
+          @include registForm;
           width: 48%;
-          height: 48px;
-          margin-top: 8px;
-          font-size: 16px;
-          line-height: 1.5;
-          padding: 0 15px;
-          border-radius: 4px;
-          border: 1px solid #ccc;
-          background: $white;
         }
       }
     }
+
     &__submit {
     margin-top: 50px;
+
       &__btn {
         background-color: $furimaColor;
         line-height: 48px;

--- a/app/assets/stylesheets/modules/users/_registrations.scss
+++ b/app/assets/stylesheets/modules/users/_registrations.scss
@@ -1,132 +1,143 @@
 @import "mixin/registForm";
+@import "mixin/footerSub";
 
 .registerBody {
   width: 100%;
   height: 100%;
   background-color: $smoke;
   font-size: 14px;
-}
 
-.registerheader {
-  height: 128px;
 
-  &__logo {
-    text-align: center;
-    line-height: 128px;
-    position: relative;
-    top: 18px;
-  }
-}
+  .registerheader {
+    height: 128px;
 
-.registerWrapper {
-  background-color: $white;
-  width: 700px;
-  margin: 0 auto;
-
-  &__head {
-    height: 97px;
-    line-height: 97px;
-    text-align: center;
-    border-bottom: 1px solid $smoke;
-
-    h2 {
-      font-size: 22px;
-      font-weight: bold;
+    &__logo {
+      text-align: center;
+      line-height: 128px;
+      position: relative;
+      top: 18px;
     }
   }
-  
-  &__content {
-    width: 343px;
+
+  .registerWrapper {
+    background-color: $white;
+    width: 700px;
     margin: 0 auto;
-    padding-bottom: 64px;
+    margin-bottom: 100px;
 
-    &__thankyou {
-      font-size: 18px;
+    &__head {
+      height: 97px;
+      line-height: 97px;
       text-align: center;
-      margin-top: 50px;
-    }
+      border-bottom: 1px solid $smoke;
 
-    &__homelink {
-      margin-top: 50px;
-      text-align: center;
-      &__btn {
-        display: block;
-        border: 1px solid $furimaColor;
-        background-color: $furimaColor;
-        color: $white;
-        width: 100%;
-        line-height: 48px;
-        font-size: 14px;
-        text-align: center;
+      h2 {
+        font-size: 22px;
+        font-weight: bold;
       }
     }
+    
+    &__content {
+      width: 343px;
+      margin: 0 auto;
+      padding-bottom: 64px;
 
-    &__formGroup {
-      margin-top: 32px;
-      width: 100%;
-
-      &__label {
-        font-weight: 600;
-
-        &--must {
-          background-color: #ea352d;
-          color: $white;
-          margin-left: 8px;
-          padding: 2px 4px;
-          border-radius: 2px;
-          font-size: 12px;
+      &--create {
+        width: 50%;
+        margin: 0 auto;
+        padding-bottom: 100px;
+        
+        &__message {
+          font-size: 18px;
+          text-align: center;
+          margin-top: 50px;
         }
 
-        &--optional {
-          background-color: $lightGray;
-          color: $white;
-          margin-left: 8px;
-          padding: 2px 4px;
-          border-radius: 2px;
-          font-size: 12px;
+        &__homelink {
+            margin-top: 70px;
+            text-align: center;
+
+          &__btn {
+              display: block;
+              border: 1px solid $furimaColor;
+              background-color: $furimaColor;
+              color: $white;
+              width: 100%;
+              line-height: 48px;
+              font-size: 14px;
+              text-align: center;
+          }
         }
       }
 
-      #delivery_address_prefecture_id {
-        width: 100%;
-        background-color: $white;
-        font-size: 16px;
-        margin-top: 8px;
-        border: 1px solid $lightGray;
-        height: 48px;
-      }
-
-      #identification_birthday_1i, #identification_birthday_2i, #identification_birthday_3i {
-        font-size: 20px;
-        margin-top: 8px;
-        background-color: $white;
-        border: 1px solid $lightGray;
-        height: 48px;
-        width: 27%;
-      }
-
-      &__form {
-        @include registForm;
+      &__formGroup {
+        margin-top: 32px;
         width: 100%;
 
-        &--half {
+        &__label {
+          font-weight: 600;
+
+          &--must {
+            background-color: #ea352d;
+            color: $white;
+            margin-left: 8px;
+            padding: 2px 4px;
+            border-radius: 2px;
+            font-size: 12px;
+          }
+
+          &--optional {
+            background-color: $lightGray;
+            color: $white;
+            margin-left: 8px;
+            padding: 2px 4px;
+            border-radius: 2px;
+            font-size: 12px;
+          }
+        }
+
+        #delivery_address_prefecture_id {
+          width: 100%;
+          background-color: $white;
+          font-size: 16px;
+          margin-top: 8px;
+          border: 1px solid $lightGray;
+          height: 48px;
+        }
+
+        #identification_birthday_1i, #identification_birthday_2i, #identification_birthday_3i {
+          font-size: 20px;
+          margin-top: 8px;
+          background-color: $white;
+          border: 1px solid $lightGray;
+          height: 48px;
+          width: 27%;
+        }
+
+        &__form {
           @include registForm;
-          width: 48%;
+          width: 100%;
+
+          &--half {
+            @include registForm;
+            width: 48%;
+          }
         }
       }
-    }
 
-    &__submit {
-    margin-top: 50px;
+      &__submit {
+      margin-top: 50px;
 
-      &__btn {
-        background-color: $furimaColor;
-        line-height: 48px;
-        color: $white;
-        font-size: 14px;
-        width: 100%;
-        border: 1px solid $furimaColor;
+        &__btn {
+          background-color: $furimaColor;
+          line-height: 48px;
+          color: $white;
+          font-size: 14px;
+          width: 100%;
+          border: 1px solid $furimaColor;
+        }
       }
     }
   }
+  @include footerSub;
 }

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -22,6 +22,19 @@ class Users::RegistrationsController < Devise::RegistrationsController
     render :new_identification
   end
 
+  def create_identification
+    @user = User.new(session["devise.regist_data"]["user"])
+    @identification = Identification.new(identification_params)
+    unless @identification.valid?
+      flash.now[:alert] = @identification.errors.full_messages
+      render :new_identification and return
+    end
+    @user.build_identification(@identification.attributes)
+    @user.save
+    session["devise.regist_data"]["user"].clear
+    sign_in(:user, @user)
+  end
+
   # GET /resource/edit
   # def edit
   #   super
@@ -46,7 +59,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
+
+  def identification_params
+    params.require(:identification).permit(:familyName, :firstName, :familyNameKana, :firstNameKana, :birthday)
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,14 +5,22 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    @user = User.new
+  end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    @user = User.new(sign_up_params)
+    unless @user.valid?
+      flash.now[:alert] = @user.errors.full_messages
+      render :new and return
+    end
+    session["devise.regist_data"] = {user: @user.attributes}
+    session["devise.regist_data"][:user]["password"] = params[:user][:password]
+    @identification = @user.build_identification
+    render :new_identification
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -22,19 +22,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     render :new_identification
   end
 
-  # def create_identification
-  #   @user = User.new(session["devise.regist_data"]["user"])
-  #   @identification = Identification.new(identification_params)
-  #   unless @identification.valid?
-  #     flash.now[:alert] = @identification.errors.full_messages
-  #     render :new_identification and return
-  #   end
-  #   @user.build_identification(@identification.attributes)
-  #   @user.save
-  #   session["devise.regist_data"]["user"].clear
-  #   sign_in(:user, @user)
-  # end
-
   def create_identification
     @user = User.new(session["devise.regist_data"]["user"])
     @identification = Identification.new(identification_params)
@@ -46,6 +33,20 @@ class Users::RegistrationsController < Devise::RegistrationsController
     session["identification"] = @identification.attributes
     @deliveryAddress = @user.build_deliveryAddress
     render :new_deliveryAddress
+  end
+
+  def create_deliveryAddress
+    @user = User.new(session["devise.regist_data"]["user"])
+    @identification = Identification.new(session["identification"])
+    @deliveryAddress = DeliveryAddress.new(deliveryAddress_params)
+    unless @deliveryAddress.valid?
+      flash.now[:alert] = @deliveryAddress.errors.full_messages
+      render :new_deliveryAddress and return
+    end
+    @user.build_identification(@identification.attributes)
+    @user.build_deliveryAddress(@deliveryAddress.attributes)
+    @user.save
+    sign_in(:user, @user)
   end
 
 
@@ -77,6 +78,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def identification_params
     params.require(:identification).permit(:familyName, :firstName, :familyNameKana, :firstNameKana, :birthday)
+  end
+
+  def deliveryAddress_params
+    params.require(:delivery_address).permit(:familyName, :firstName, :familyNameKana, :firstNameKana, :postCode, :prefecture_id, :city, :address, :buildingName, :telNumber)
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -22,6 +22,19 @@ class Users::RegistrationsController < Devise::RegistrationsController
     render :new_identification
   end
 
+  # def create_identification
+  #   @user = User.new(session["devise.regist_data"]["user"])
+  #   @identification = Identification.new(identification_params)
+  #   unless @identification.valid?
+  #     flash.now[:alert] = @identification.errors.full_messages
+  #     render :new_identification and return
+  #   end
+  #   @user.build_identification(@identification.attributes)
+  #   @user.save
+  #   session["devise.regist_data"]["user"].clear
+  #   sign_in(:user, @user)
+  # end
+
   def create_identification
     @user = User.new(session["devise.regist_data"]["user"])
     @identification = Identification.new(identification_params)
@@ -30,10 +43,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
       render :new_identification and return
     end
     @user.build_identification(@identification.attributes)
-    @user.save
-    session["devise.regist_data"]["user"].clear
-    sign_in(:user, @user)
+    session["identification"] = @identification.attributes
+    @deliveryAddress = @user.build_deliveryAddress
+    render :new_deliveryAddress
   end
+
 
   # GET /resource/edit
   # def edit

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -1,0 +1,2 @@
+class DeliveryAddress < ApplicationRecord
+end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -1,2 +1,4 @@
 class DeliveryAddress < ApplicationRecord
+  belongs_to :user, optional: true
+  validates :familyName, :firstName, :familyNameKana, :firstNameKana, :postCode, :prefecture_id, :city, :address, presence: true
 end

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -1,0 +1,2 @@
+class Identification < ApplicationRecord
+end

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -1,2 +1,4 @@
 class Identification < ApplicationRecord
+  belongs_to :user, optional: true
+  validates :familyName, :firstName, :familyNameKana, :firstNameKana, :birthday, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :goods
+  has_one :identification
   
   validates :nickname, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :goods
   has_one :identification
+  has_one :deliveryAddress
   
   validates :nickname, presence: true
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,8 +5,8 @@ class ImageUploader < CarrierWave::Uploader::Base
   # process resize_to_fit: [800, 800]
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -45,4 +45,10 @@ class ImageUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
+
+  if Rails.env.development? || Rails.env.test?
+  storage :file
+  else
+    storage :fog
+  end
 end

--- a/app/views/devise/registrations/_header_registration.html.haml
+++ b/app/views/devise/registrations/_header_registration.html.haml
@@ -1,0 +1,3 @@
+.registerheader
+  .registerheader__logo
+    = image_tag 'logo.png', alt: 'furimalogo', height: '49', width: '185', class: ''

--- a/app/views/devise/registrations/create_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/create_deliveryAddress.html.haml
@@ -2,3 +2,9 @@
   .registerWrapper
     .registerWrapper__head
       %h2 会員登録完了
+    .registerWrapper__content
+      .registerWrapper__content__thankyou
+        %p ありがとうがざいます。
+        %p 会員登録が完了しました。
+      .registerWrapper__content__homelink
+        = link_to 'トップページに戻る', root_path, class: "registerWrapper__content__homelink__btn"

--- a/app/views/devise/registrations/create_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/create_deliveryAddress.html.haml
@@ -1,0 +1,4 @@
+.registerBody  
+  .registerWrapper
+    .registerWrapper__head
+      %h2 会員登録完了

--- a/app/views/devise/registrations/create_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/create_deliveryAddress.html.haml
@@ -4,9 +4,11 @@
   .registerWrapper
     .registerWrapper__head
       %h2 会員登録完了
-    .registerWrapper__content
-      .registerWrapper__content__thankyou
+    .registerWrapper__content--create
+      .registerWrapper__content--create__message
         %p ありがとうがざいます。
         %p 会員登録が完了しました。
-      .registerWrapper__content__homelink
-        = link_to 'トップページに戻る', root_path, class: "registerWrapper__content__homelink__btn"
+      .registerWrapper__content--create__homelink
+        = link_to 'トップページに戻る', root_path, class: "registerWrapper__content--create__homelink__btn"
+  
+  = render partial: 'modules/footerSub'

--- a/app/views/devise/registrations/create_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/create_deliveryAddress.html.haml
@@ -1,4 +1,6 @@
-.registerBody  
+.registerBody
+  = render partial: 'header_registration'
+
   .registerWrapper
     .registerWrapper__head
       %h2 会員登録完了

--- a/app/views/devise/registrations/create_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/create_deliveryAddress.html.haml
@@ -6,7 +6,7 @@
       %h2 会員登録完了
     .registerWrapper__content--create
       .registerWrapper__content--create__message
-        %p ありがとうがざいます。
+        %p ありがとうございます。
         %p 会員登録が完了しました。
       .registerWrapper__content--create__homelink
         = link_to 'トップページに戻る', root_path, class: "registerWrapper__content--create__homelink__btn"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -3,8 +3,8 @@
     .registerWrapper__head
       %h2 会員情報入力
     .registerWrapper__content
-      = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-        = render "devise/shared/error_messages", resource: resource
+      = form_for(@user, url: user_registration_path) do |f|
+        = render "devise/shared/error_messages", resource: @user
         .registerWrapper__content__formGroup
           = f.label :ニックネーム, class: 'registerWrapper__content__formGroup__label'
           %span 必須
@@ -27,4 +27,4 @@
           %br/
           = f.password_field :password_confirmation, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '上記と同じパスワードを入力してください'
         .registerWrapper__content__submit
-          = f.submit "登録する" ,class: 'registerWrapper__content__submit__btn'
+          = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,26 +5,31 @@
     .registerWrapper__content
       = form_for(@user, url: user_registration_path, method: :post) do |f|
         = render "devise/shared/error_messages", resource: @user
+        
         .registerWrapper__content__formGroup
           = f.label :ニックネーム, class: 'registerWrapper__content__formGroup__label'
-          %span 必須
+          %span.registerWrapper__content__formGroup__label--must 必須
           %br/
           = f.text_field :nickname, autofocus: true, autocomplete: "nickname", class: 'registerWrapper__content__formGroup__form', placeholder: '例) フリマ太郎'
+        
         .registerWrapper__content__formGroup
           = f.label :メールアドレス, class: 'registerWrapper__content__formGroup__label'
-          %span 必須
+          %span.registerWrapper__content__formGroup__label--must 必須
           %br/
           = f.email_field :email, autofocus: true, autocomplete: "email", class: 'registerWrapper__content__formGroup__form', placeholder: 'PC・携帯どちらでも可'
+        
         .registerWrapper__content__formGroup
           = f.label :パスワード, class: 'registerWrapper__content__formGroup__label'
           - if @minimum_password_length
-            %span 必須
+            %span.registerWrapper__content__formGroup__label--must 必須
           %br/
           = f.password_field :password, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '７文字以上の半角英数字'
+        
         .registerWrapper__content__formGroup
           = f.label :パスワードの確認, class: 'registerWrapper__content__formGroup__label'
-          %span 必須
+          %span.registerWrapper__content__formGroup__label--must 必須
           %br/
           = f.password_field :password_confirmation, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '上記と同じパスワードを入力してください'
+        
         .registerWrapper__content__submit
           = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,35 +1,55 @@
 .registerBody  
   .registerWrapper
     .registerWrapper__head
-      %h2 会員情報入力
+      %h2 会員登録完了
     .registerWrapper__content
-      = form_for(@user, url: user_registration_path, method: :post) do |f|
-        = render "devise/shared/error_messages", resource: @user
+      .registerWrapper__content__thankyou
+        %p ありがとうがざいます。
+        %p 会員登録が完了しました。
+      .registerWrapper__content__homelink
+        = link_to 'トップページに戻る', root_path, class: "registerWrapper__content__homelink__btn"
+
+
+
+
+
+
+
+
+
+
+-# .registerBody  
+-#   .registerWrapper
+-#     .registerWrapper__head
+-#       %h2 会員登録完了
+    -# .registerWrapper__content
+    -#   = form_for(@user, url: user_registration_path, method: :post) do |f|
+    -#     = render "devise/shared/error_messages", resource: @user
         
-        .registerWrapper__content__formGroup
-          = f.label :ニックネーム, class: 'registerWrapper__content__formGroup__label'
-          %span.registerWrapper__content__formGroup__label--must 必須
-          %br/
-          = f.text_field :nickname, autofocus: true, autocomplete: "nickname", class: 'registerWrapper__content__formGroup__form', placeholder: '例) フリマ太郎'
+    -#     .registerWrapper__content__formGroup
+    -#       = f.label :ニックネーム, class: 'registerWrapper__content__formGroup__label'
+    -#       %span.registerWrapper__content__formGroup__label--must 必須
+    -#       %br/
+    -#       = f.text_field :nickname, autofocus: true, autocomplete: "nickname", class: 'registerWrapper__content__formGroup__form', placeholder: '例) フリマ太郎'
         
-        .registerWrapper__content__formGroup
-          = f.label :メールアドレス, class: 'registerWrapper__content__formGroup__label'
-          %span.registerWrapper__content__formGroup__label--must 必須
-          %br/
-          = f.email_field :email, autofocus: true, autocomplete: "email", class: 'registerWrapper__content__formGroup__form', placeholder: 'PC・携帯どちらでも可'
+    -#     .registerWrapper__content__formGroup
+    -#       = f.label :メールアドレス, class: 'registerWrapper__content__formGroup__label'
+    -#       %span.registerWrapper__content__formGroup__label--must 必須
+    -#       %br/
+    -#       = f.email_field :email, autofocus: true, autocomplete: "email", class: 'registerWrapper__content__formGroup__form', placeholder: 'PC・携帯どちらでも可'
         
-        .registerWrapper__content__formGroup
-          = f.label :パスワード, class: 'registerWrapper__content__formGroup__label'
-          - if @minimum_password_length
-            %span.registerWrapper__content__formGroup__label--must 必須
-          %br/
-          = f.password_field :password, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '７文字以上の半角英数字'
+    -#     .registerWrapper__content__formGroup
+    -#       = f.label :パスワード, class: 'registerWrapper__content__formGroup__label'
+    -#       - if @minimum_password_length
+    -#         %span.registerWrapper__content__formGroup__label--must 必須
+    -#       %br/
+    -#       = f.password_field :password, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '７文字以上の半角英数字'
         
-        .registerWrapper__content__formGroup
-          = f.label :パスワードの確認, class: 'registerWrapper__content__formGroup__label'
-          %span.registerWrapper__content__formGroup__label--must 必須
-          %br/
-          = f.password_field :password_confirmation, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '上記と同じパスワードを入力してください'
+    -#     .registerWrapper__content__formGroup
+    -#       = f.label :パスワードの確認, class: 'registerWrapper__content__formGroup__label'
+    -#       %span.registerWrapper__content__formGroup__label--must 必須
+    -#       %br/
+    -#       = f.password_field :password_confirmation, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '上記と同じパスワードを入力してください'
         
-        .registerWrapper__content__submit
-          = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'
+    -#     .registerWrapper__content__submit
+    -#       = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -35,3 +35,5 @@
         
         .registerWrapper__content__submit
           = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'
+
+  = render partial: 'modules/footerSub'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -3,7 +3,7 @@
     .registerWrapper__head
       %h2 会員情報入力
     .registerWrapper__content
-      = form_for(@user, url: user_registration_path) do |f|
+      = form_for(@user, url: user_registration_path, method: :post) do |f|
         = render "devise/shared/error_messages", resource: @user
         .registerWrapper__content__formGroup
           = f.label :ニックネーム, class: 'registerWrapper__content__formGroup__label'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -3,7 +3,7 @@
   
   .registerWrapper
     .registerWrapper__head
-      %h2 会員登録完了
+      %h2 会員情報入力
     .registerWrapper__content
       = form_for(@user, url: user_registration_path, method: :post) do |f|
         = render "devise/shared/error_messages", resource: @user

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,55 +1,38 @@
-.registerBody  
+.registerBody 
+  .registerheader
+    .registerheader__logo
+      = image_tag 'logo.png', alt: 'furimalogo', height: '49', width: '185', class: ''
   .registerWrapper
     .registerWrapper__head
       %h2 会員登録完了
     .registerWrapper__content
-      .registerWrapper__content__thankyou
-        %p ありがとうがざいます。
-        %p 会員登録が完了しました。
-      .registerWrapper__content__homelink
-        = link_to 'トップページに戻る', root_path, class: "registerWrapper__content__homelink__btn"
-
-
-
-
-
-
-
-
-
-
--# .registerBody  
--#   .registerWrapper
--#     .registerWrapper__head
--#       %h2 会員登録完了
-    -# .registerWrapper__content
-    -#   = form_for(@user, url: user_registration_path, method: :post) do |f|
-    -#     = render "devise/shared/error_messages", resource: @user
+      = form_for(@user, url: user_registration_path, method: :post) do |f|
+        = render "devise/shared/error_messages", resource: @user
         
-    -#     .registerWrapper__content__formGroup
-    -#       = f.label :ニックネーム, class: 'registerWrapper__content__formGroup__label'
-    -#       %span.registerWrapper__content__formGroup__label--must 必須
-    -#       %br/
-    -#       = f.text_field :nickname, autofocus: true, autocomplete: "nickname", class: 'registerWrapper__content__formGroup__form', placeholder: '例) フリマ太郎'
+        .registerWrapper__content__formGroup
+          = f.label :ニックネーム, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.text_field :nickname, autofocus: true, autocomplete: "nickname", class: 'registerWrapper__content__formGroup__form', placeholder: '例) フリマ太郎'
         
-    -#     .registerWrapper__content__formGroup
-    -#       = f.label :メールアドレス, class: 'registerWrapper__content__formGroup__label'
-    -#       %span.registerWrapper__content__formGroup__label--must 必須
-    -#       %br/
-    -#       = f.email_field :email, autofocus: true, autocomplete: "email", class: 'registerWrapper__content__formGroup__form', placeholder: 'PC・携帯どちらでも可'
+        .registerWrapper__content__formGroup
+          = f.label :メールアドレス, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.email_field :email, autofocus: true, autocomplete: "email", class: 'registerWrapper__content__formGroup__form', placeholder: 'PC・携帯どちらでも可'
         
-    -#     .registerWrapper__content__formGroup
-    -#       = f.label :パスワード, class: 'registerWrapper__content__formGroup__label'
-    -#       - if @minimum_password_length
-    -#         %span.registerWrapper__content__formGroup__label--must 必須
-    -#       %br/
-    -#       = f.password_field :password, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '７文字以上の半角英数字'
+        .registerWrapper__content__formGroup
+          = f.label :パスワード, class: 'registerWrapper__content__formGroup__label'
+          - if @minimum_password_length
+            %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.password_field :password, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '７文字以上の半角英数字'
         
-    -#     .registerWrapper__content__formGroup
-    -#       = f.label :パスワードの確認, class: 'registerWrapper__content__formGroup__label'
-    -#       %span.registerWrapper__content__formGroup__label--must 必須
-    -#       %br/
-    -#       = f.password_field :password_confirmation, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '上記と同じパスワードを入力してください'
+        .registerWrapper__content__formGroup
+          = f.label :パスワードの確認, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.password_field :password_confirmation, autocomplete: "new-password", class: 'registerWrapper__content__formGroup__form', placeholder: '上記と同じパスワードを入力してください'
         
-    -#     .registerWrapper__content__submit
-    -#       = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'
+        .registerWrapper__content__submit
+          = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,7 +1,6 @@
 .registerBody 
-  .registerheader
-    .registerheader__logo
-      = image_tag 'logo.png', alt: 'furimalogo', height: '49', width: '185', class: ''
+  = render partial: 'header_registration'
+  
   .registerWrapper
     .registerWrapper__head
       %h2 会員登録完了

--- a/app/views/devise/registrations/new_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/new_deliveryAddress.html.haml
@@ -1,4 +1,6 @@
-.registerBody  
+.registerBody
+  = render partial: 'header_registration'
+
   .registerWrapper
     .registerWrapper__head
       %h2 発送元・お届け先住所入力

--- a/app/views/devise/registrations/new_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/new_deliveryAddress.html.haml
@@ -60,3 +60,5 @@
 
         .registerWrapper__content__submit
           = f.submit "この内容で会員登録する" ,class: 'registerWrapper__content__submit__btn'
+
+  = render partial: 'modules/footerSub'

--- a/app/views/devise/registrations/new_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/new_deliveryAddress.html.haml
@@ -1,27 +1,64 @@
 .registerBody  
   .registerWrapper
     .registerWrapper__head
-      %h2 商品送付先住所入力
-    -# .registerWrapper__content
-    -#   = form_for(@deliveryAddress, url: deliveryAddresses_path, method: :post) do |f|
-    -#     = render "devise/shared/error_messages", resource: @deliveryAddress
-    -#     .registerWrapper__content__formGroup
-    -#       = f.label :お名前（全角）, class: 'registerWrapper__content__formGroup__label'
-    -#       %span 必須
-    -#       %br/
-    -#       = f.text_field :familyName, autofocus: true, autocomplete: "familyName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 振間'
-    -#       = f.text_field :firstName, autofocus: true, autocomplete: "firstName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 太郎'
-    -#     .registerWrapper__content__formGroup
-    -#       = f.label :お名前かな（全角）, class: 'registerWrapper__content__formGroup__label'
-    -#       %span 必須
-    -#       %br/
-    -#       = f.text_field :familyNameKana, autofocus: true, autocomplete: "familyNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) ふりま'
-    -#       = f.text_field :firstNameKana, autofocus: true, autocomplete: "firstNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) たろう'
-    -#     .registerWrapper__content__formGroup
-    -#       = f.label :生年月日, class: 'registerWrapper__content__formGroup__label'
-    -#       %span 必須
-    -#       %br/
-    -#       != sprintf(f.date_select(:birthday, use_month_numbers: true, start_year:1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1), date_separator: '%s'), '年', '月')+'日'
+      %h2 発送元・お届け先住所入力
+    .registerWrapper__content
+      = form_for(@deliveryAddress, url: deliveryAddresses_path, method: :post) do |f|
+        = render "devise/shared/error_messages", resource: @deliveryAddress
 
-    -#     .registerWrapper__content__submit
-    -#       = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'
+        .registerWrapper__content__formGroup
+          = f.label :お名前, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.text_field :familyName, autofocus: true, autocomplete: "familyName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 振間'
+          = f.text_field :firstName, autofocus: true, autocomplete: "firstName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 太郎'
+
+        .registerWrapper__content__formGroup
+          = f.label :お名前かな, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.text_field :familyNameKana, autofocus: true, autocomplete: "familyNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) ふりま'
+          = f.text_field :firstNameKana, autofocus: true, autocomplete: "firstNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) たろう'
+
+        .registerWrapper__content__formGroup
+          = f.label :郵便番号, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.text_field :postCode, autofocus: true, autocomplete: "postCode", class: 'registerWrapper__content__formGroup__form', placeholder: '例) 123-4567'
+
+
+
+        .registerWrapper__content__formGroup
+          = f.label :都道府県, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須          
+        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択してください"
+
+
+
+
+        .registerWrapper__content__formGroup
+          = f.label :市区町村, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.text_field :city, autofocus: true, autocomplete: "city", class: 'registerWrapper__content__formGroup__form', placeholder: '例) 渋谷区'
+
+        .registerWrapper__content__formGroup
+          = f.label :番地, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.text_field :address, autofocus: true, autocomplete: "address", class: 'registerWrapper__content__formGroup__form', placeholder: '例) 道玄坂２−２３−１２'
+
+        .registerWrapper__content__formGroup
+          = f.label :建物名, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--optional 任意
+          %br/
+          = f.text_field :buildingName, autofocus: true, autocomplete: "buildingName", class: 'registerWrapper__content__formGroup__form', placeholder: '例) フォンティスビル７F'
+
+        .registerWrapper__content__formGroup
+          = f.label :電話番号, class: 'registerWrapper__content__formGroup__label'
+          %span.registerWrapper__content__formGroup__label--optional 任意
+          %br/
+          = f.text_field :telNumber, autofocus: true, autocomplete: "telNumber", class: 'registerWrapper__content__formGroup__form', placeholder: '例) 09012345678'
+
+        .registerWrapper__content__submit
+          = f.submit "この内容で会員登録する" ,class: 'registerWrapper__content__submit__btn'

--- a/app/views/devise/registrations/new_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/new_deliveryAddress.html.haml
@@ -26,15 +26,11 @@
           %br/
           = f.text_field :postCode, autofocus: true, autocomplete: "postCode", class: 'registerWrapper__content__formGroup__form', placeholder: '例) 123-4567'
 
-
-
         .registerWrapper__content__formGroup
           = f.label :都道府県, class: 'registerWrapper__content__formGroup__label'
-          %span.registerWrapper__content__formGroup__label--must 必須          
-        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択してください"
-
-
-
+          %span.registerWrapper__content__formGroup__label--must 必須
+          %br/
+          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択してください"
 
         .registerWrapper__content__formGroup
           = f.label :市区町村, class: 'registerWrapper__content__formGroup__label'

--- a/app/views/devise/registrations/new_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/new_deliveryAddress.html.haml
@@ -1,0 +1,27 @@
+.registerBody  
+  .registerWrapper
+    .registerWrapper__head
+      %h2 商品送付先住所入力
+    -# .registerWrapper__content
+    -#   = form_for(@deliveryAddress, url: deliveryAddresses_path, method: :post) do |f|
+    -#     = render "devise/shared/error_messages", resource: @deliveryAddress
+    -#     .registerWrapper__content__formGroup
+    -#       = f.label :お名前（全角）, class: 'registerWrapper__content__formGroup__label'
+    -#       %span 必須
+    -#       %br/
+    -#       = f.text_field :familyName, autofocus: true, autocomplete: "familyName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 振間'
+    -#       = f.text_field :firstName, autofocus: true, autocomplete: "firstName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 太郎'
+    -#     .registerWrapper__content__formGroup
+    -#       = f.label :お名前かな（全角）, class: 'registerWrapper__content__formGroup__label'
+    -#       %span 必須
+    -#       %br/
+    -#       = f.text_field :familyNameKana, autofocus: true, autocomplete: "familyNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) ふりま'
+    -#       = f.text_field :firstNameKana, autofocus: true, autocomplete: "firstNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) たろう'
+    -#     .registerWrapper__content__formGroup
+    -#       = f.label :生年月日, class: 'registerWrapper__content__formGroup__label'
+    -#       %span 必須
+    -#       %br/
+    -#       != sprintf(f.date_select(:birthday, use_month_numbers: true, start_year:1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1), date_separator: '%s'), '年', '月')+'日'
+
+    -#     .registerWrapper__content__submit
+    -#       = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'

--- a/app/views/devise/registrations/new_identification.html.haml
+++ b/app/views/devise/registrations/new_identification.html.haml
@@ -1,0 +1,27 @@
+.registerBody  
+  .registerWrapper
+    .registerWrapper__head
+      %h2 会員情報入力
+    .registerWrapper__content
+      = form_for @identification do |f|
+        = render "devise/shared/error_messages", resource: @identification
+        .registerWrapper__content__formGroup
+          = f.label :お名前（全角）, class: 'registerWrapper__content__formGroup__label'
+          %span 必須
+          %br/
+          = f.text_field :familyName, autofocus: true, autocomplete: "familyName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 振間'
+          = f.text_field :firstName, autofocus: true, autocomplete: "firstName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 太郎'
+        .registerWrapper__content__formGroup
+          = f.label :お名前かな（全角）, class: 'registerWrapper__content__formGroup__label'
+          %span 必須
+          %br/
+          = f.text_field :familyNameKana, autofocus: true, autocomplete: "familyNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) ふりま'
+          = f.text_field :firstNameKana, autofocus: true, autocomplete: "firstNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) たろう'
+        .registerWrapper__content__formGroup
+          = f.label :生年月日, class: 'registerWrapper__content__formGroup__label'
+          %span 必須
+          %br/
+          != sprintf(f.date_select(:birthday, use_month_numbers: true, start_year:1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1), date_separator: '%s'), '年', '月')+'日'
+
+        .registerWrapper__content__submit
+          = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'

--- a/app/views/devise/registrations/new_identification.html.haml
+++ b/app/views/devise/registrations/new_identification.html.haml
@@ -30,3 +30,5 @@
 
         .registerWrapper__content__submit
           = f.submit "次へ進む" ,class: 'registerWrapper__content__submit__btn'
+          
+  = render partial: 'modules/footerSub'

--- a/app/views/devise/registrations/new_identification.html.haml
+++ b/app/views/devise/registrations/new_identification.html.haml
@@ -5,21 +5,24 @@
     .registerWrapper__content
       = form_for(@identification, url: identifications_path, method: :post) do |f|
         = render "devise/shared/error_messages", resource: @identification
+        
         .registerWrapper__content__formGroup
           = f.label :お名前（全角）, class: 'registerWrapper__content__formGroup__label'
-          %span 必須
+          %span.registerWrapper__content__formGroup__label--must 必須
           %br/
           = f.text_field :familyName, autofocus: true, autocomplete: "familyName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 振間'
           = f.text_field :firstName, autofocus: true, autocomplete: "firstName", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) 太郎'
+        
         .registerWrapper__content__formGroup
           = f.label :お名前かな（全角）, class: 'registerWrapper__content__formGroup__label'
-          %span 必須
+          %span.registerWrapper__content__formGroup__label--must 必須
           %br/
           = f.text_field :familyNameKana, autofocus: true, autocomplete: "familyNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) ふりま'
           = f.text_field :firstNameKana, autofocus: true, autocomplete: "firstNameKana", class: 'registerWrapper__content__formGroup__form--half', placeholder: '例) たろう'
+        
         .registerWrapper__content__formGroup
           = f.label :生年月日, class: 'registerWrapper__content__formGroup__label'
-          %span 必須
+          %span.registerWrapper__content__formGroup__label--must 必須
           %br/
           != sprintf(f.date_select(:birthday, use_month_numbers: true, start_year:1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1), date_separator: '%s'), '年', '月')+'日'
 

--- a/app/views/devise/registrations/new_identification.html.haml
+++ b/app/views/devise/registrations/new_identification.html.haml
@@ -1,9 +1,9 @@
 .registerBody  
   .registerWrapper
     .registerWrapper__head
-      %h2 会員情報入力
+      %h2 本人確認情報入力
     .registerWrapper__content
-      = form_for @identification do |f|
+      = form_for(@identification, url: identifications_path, method: :post) do |f|
         = render "devise/shared/error_messages", resource: @identification
         .registerWrapper__content__formGroup
           = f.label :お名前（全角）, class: 'registerWrapper__content__formGroup__label'

--- a/app/views/devise/registrations/new_identification.html.haml
+++ b/app/views/devise/registrations/new_identification.html.haml
@@ -1,4 +1,6 @@
-.registerBody  
+.registerBody
+  = render partial: 'header_registration'
+
   .registerWrapper
     .registerWrapper__head
       %h2 本人確認情報入力

--- a/app/views/goods/new.html.haml
+++ b/app/views/goods/new.html.haml
@@ -35,7 +35,9 @@
         .detail__category
           %span.detail__category--text カテゴリー
           %span.detail__category--must 必須
-        = f.collection_select :category_id, @parents, :id, :categoryName, prompt: "選択してください"
+        .selectBox  
+          = f.collection_select :category_id, @parents, :id, :categoryName, prompt: "選択してください"
+          %i.fas.fa-chevron-down
         .detail__brand
           %span.detail__brand--text ブランド
           %span.detail__brand--option 任意
@@ -43,7 +45,9 @@
         .detail__condition
           %span.detail__condition--text 商品の状態
           %span.detail__condition--must 必須
-        = f.select :goodsCondition, [["新品、未使用"],["未使用に近い"],["目立った傷や汚れなし"],["やや傷や汚れあり"],["傷や汚れあり"],["全体的に状態が悪い"]], prompt: "選択してください", class: 'detail__condition--fork'
+        .selectBox
+          = f.select :goodsCondition, [["新品、未使用"],["未使用に近い"],["目立った傷や汚れなし"],["やや傷や汚れあり"],["傷や汚れあり"],["全体的に状態が悪い"]], prompt: "選択してください", class: 'detail__condition--fork'
+          %i.fas.fa-chevron-down
 
 
 
@@ -52,15 +56,21 @@
         .delivery__fee
           %span.delivery__fee--text 配送料の負担
           %span.delivery__fee--must 必須
-        = f.select :deliveryFee, [["送料込み（出品者負担）"],["着払い（購入者負担）"]], prompt: "選択してください", class: 'delivery__fee--form'
+        .selectBox
+          = f.select :deliveryFee, [["送料込み（出品者負担）"],["着払い（購入者負担）"]], prompt: "選択してください", class: 'delivery__fee--form'
+          %i.fas.fa-chevron-down
         .delivery__prefecture
           %span.delivery__prefecture--text 発送の地域
           %span.delivery__prefecture--must 必須
-        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択してください"
+        .selectBox
+          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択してください"
+          %i.fas.fa-chevron-down
         .delivery__day
           %span.delivery__day--text 発送までの日数
           %span.delivery__day--must 必須
-        = f.select :deliveryDay, [["1~2日で発送"],["2~3日で発送"],["3~7日で発送"]], prompt: "選択してください", class: 'delivery__day--form'
+        .selectBox
+          = f.select :deliveryDay, [["1~2日で発送"],["2~3日で発送"],["3~7日で発送"]], prompt: "選択してください", class: 'delivery__day--form'
+          %i.fas.fa-chevron-down
 
 
 

--- a/app/views/goods/show.html.haml
+++ b/app/views/goods/show.html.haml
@@ -15,11 +15,9 @@
         %i.fas.fa-chevron-right.iconChevronRight
         = link_to "まいご犬", "#", class: "cateProductName"
 
-
 .showGoods
   .showGoods__showGoodsBody
     .showGoods__showGoodsBody__showGoodsBodyMain
-
       .showGoods__showGoodsBody__showGoodsBodyMain__showGoodsBodyMainSelect
         %h1.selectItemName
           まいご犬

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -32,5 +32,5 @@
           © FURIMA
 
 .displayBtn
-  = link_to "出品する", root_path, class: "displayWord"
+  = link_to "出品する", new_good_path, class: "displayWord"
   %i.fas.fa-camera.iconCamera

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -35,6 +35,8 @@
             ログアウト
       - else
         %li
-          = link_to "#" do
+          = link_to new_user_session_path do
             %i{class: "fas fa-smile"}
-            ログイン/新規会員登録
+            ログイン/
+          = link_to new_user_registration_path do
+            新規登録

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -23,12 +23,18 @@
       %li
         %i{class: "fas fa-check"}
         やることリスト
-      %li
-        - if user_signed_in?
+
+      - if user_signed_in?
+        %li 
           = link_to "#" do
             %i{class: "fas fa-smile"}
             マイページへ
-        - else
+        %li
+          = link_to destroy_user_session_path, method: :delete do
+            %i{class: "fas fa-sign-out-alt"}
+            ログアウト
+      - else
+        %li
           = link_to "#" do
             %i{class: "fas fa-smile"}
             ログイン/新規会員登録

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,20 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  if Rails.env.development? || Rails.env.test?
+    config.storage = :file
+  else
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1'
+    }
+    config.fog_directory  = 'fleamarket-sample-74f'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/fleamarket-sample-74f'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,12 @@ Rails.application.routes.draw do
     registrations: 'users/registrations',
   }
   devise_scope :user do
-    get 'identification', to: 'users/registrations#new_identification'
+    get 'identifications', to: 'users/registrations#new_identification'
     post 'identifications', to: 'users/registrations#create_identification'
+    get 'deliveryAddresses', to: 'users/registrations#new_deliveryAddress'
+    post 'deliveryAddresses', to: 'users/registrations#create_deliveryAddress'
   end
-  
+
   root 'goods#index'
   resources :goods
   resources :users, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+  }
   root 'goods#index'
   resources :goods
   resources :users, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,13 @@
 Rails.application.routes.draw do
+
   devise_for :users, controllers: {
     registrations: 'users/registrations',
   }
+  devise_scope :user do
+    get 'identification', to: 'users/registrations#new_identification'
+    post 'identifications', to: 'users/registrations#create_identification'
+  end
+  
   root 'goods#index'
   resources :goods
   resources :users, only: :show

--- a/db/migrate/20200511075752_create_identifications.rb
+++ b/db/migrate/20200511075752_create_identifications.rb
@@ -1,0 +1,8 @@
+class CreateIdentifications < ActiveRecord::Migration[5.2]
+  def change
+    create_table :identifications do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200511075752_create_identifications.rb
+++ b/db/migrate/20200511075752_create_identifications.rb
@@ -1,6 +1,12 @@
 class CreateIdentifications < ActiveRecord::Migration[5.2]
   def change
     create_table :identifications do |t|
+      t.string :familyName, null: false
+      t.string :firstName, null: false
+      t.string :familyNameKana, null: false
+      t.string :firstNameKana, null: false
+      t.date :birthday, null: false
+      t.references :user, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20200512025909_create_delivery_addresses.rb
+++ b/db/migrate/20200512025909_create_delivery_addresses.rb
@@ -1,0 +1,8 @@
+class CreateDeliveryAddresses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :delivery_addresses do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200512025909_create_delivery_addresses.rb
+++ b/db/migrate/20200512025909_create_delivery_addresses.rb
@@ -1,6 +1,17 @@
 class CreateDeliveryAddresses < ActiveRecord::Migration[5.2]
   def change
     create_table :delivery_addresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :familyName, null: false
+      t.string :firstName, null: false
+      t.string :familyNameKana, null: false
+      t.string :firstNameKana, null: false
+      t.integer :postCode, null: false
+      t.integer :prefecture_id, null: false
+      t.string :city, null: false
+      t.string :address, null: false
+      t.string :buildingName
+      t.integer :telNumber
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_025016) do
+ActiveRecord::Schema.define(version: 2020_05_11_075752) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "categoryName", null: false
@@ -40,6 +40,18 @@ ActiveRecord::Schema.define(version: 2020_05_11_025016) do
     t.index ["user_id"], name: "index_goods_on_user_id"
   end
 
+  create_table "identifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "familyName", null: false
+    t.string "firstName", null: false
+    t.string "familyNameKana", null: false
+    t.string "firstNameKana", null: false
+    t.date "birthday", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_identifications_on_user_id"
+  end
+
   create_table "pictures", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "good_id", null: false
     t.string "goodsImage", null: false
@@ -63,5 +75,6 @@ ActiveRecord::Schema.define(version: 2020_05_11_025016) do
 
   add_foreign_key "goods", "categories"
   add_foreign_key "goods", "users"
+  add_foreign_key "identifications", "users"
   add_foreign_key "pictures", "goods"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_075752) do
+ActiveRecord::Schema.define(version: 2020_05_12_025909) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "categoryName", null: false
@@ -19,6 +19,23 @@ ActiveRecord::Schema.define(version: 2020_05_11_075752) do
     t.string "ancestry"
     t.index ["ancestry"], name: "index_categories_on_ancestry"
     t.index ["categoryName"], name: "index_categories_on_categoryName"
+  end
+
+  create_table "delivery_addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "familyName", null: false
+    t.string "firstName", null: false
+    t.string "familyNameKana", null: false
+    t.string "firstNameKana", null: false
+    t.integer "postCode", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "address", null: false
+    t.string "buildingName"
+    t.integer "telNumber"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_delivery_addresses_on_user_id"
   end
 
   create_table "goods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -73,6 +90,7 @@ ActiveRecord::Schema.define(version: 2020_05_11_075752) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "delivery_addresses", "users"
   add_foreign_key "goods", "categories"
   add_foreign_key "goods", "users"
   add_foreign_key "identifications", "users"

--- a/test/fixtures/delivery_addresses.yml
+++ b/test/fixtures/delivery_addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/identifications.yml
+++ b/test/fixtures/identifications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/delivery_address_test.rb
+++ b/test/models/delivery_address_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DeliveryAddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/identification_test.rb
+++ b/test/models/identification_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class IdentificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#What
新規会員登録ページのマークアップおよび各項目のDBへの登録を行なった。新規会員登録ページはウィザード形式で３ページ作成し、それぞれusers、identifications、deliveryAddressesテーブルに保存される。当ページヘッダーに現在どの情報を入力しているかの表示があった方が良いので後日実装予定。
また、DBのカラムについて変更箇所があったのでREADMEを修正した。
最後に、トップページヘッダーのログイン、新規会員登録、ログアウトにリンクを設定し各ページに飛べるよう設定した。（ログインページのマークアップは未実装、ログインは出来ます！）

#why
会員登録することで本アプリケーションを十分に使用できるから。