### PR TITLE
ユーザー新規登録関係のバリデーションの設定およびエラー文の追加、モデルの単体テスト

### DIFF
--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -3,5 +3,14 @@ class DeliveryAddress < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
 
-  validates :familyName, :firstName, :familyNameKana, :firstNameKana, :postCode, :prefecture_id, :city, :address, presence: true
+  validates :familyName, :firstName, :prefecture_id, :city, :address, presence: true
+
+  validates :familyNameKana, :firstNameKana, presence: true,
+                                              format: {
+                                                with: /\A[ぁ-ん]+\z/,
+                                                message: "はひらがなで入力してください"
+                                              }
+
+  validates :postCode, length: { is: 7}, presence: true
+                                                
 end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -12,5 +12,5 @@ class DeliveryAddress < ApplicationRecord
                                               }
 
   validates :postCode, length: { is: 7}, presence: true
-                                                
+
 end

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -2,16 +2,17 @@ class Identification < ApplicationRecord
   belongs_to :user, optional: true
   validates :birthday, presence: true
 
-  validates :familyNameKana, :firstNameKana, presence: true,
-                                              format: {
-                                                with: /\A[ぁ-ん]+\z/,
-                                                message: "は全角ひらがなで入力してください"
-                                              }
 
   validates :familyName, :firstName, presence: true,
                                       format: {
                                       with: /\A[ぁ-んァ-ヶー一-龠]+\z/,
                                       message: "は全角で入力してください"
+                                      }
+
+  validates :familyNameKana, :firstNameKana, presence: true,
+                                      format: {
+                                        with: /\A[ぁ-ん]+\z/,
+                                        message: "は全角ひらがなで入力してください"
                                       }
 
 end

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -1,4 +1,17 @@
 class Identification < ApplicationRecord
   belongs_to :user, optional: true
-  validates :familyName, :firstName, :familyNameKana, :firstNameKana, :birthday, presence: true
+  validates :birthday, presence: true
+
+  validates :familyNameKana, :firstNameKana, presence: true,
+                                              format: {
+                                                with: /\A[ぁ-ん]+\z/,
+                                                message: "は全角ひらがなで入力してください"
+                                              }
+
+  validates :familyName, :firstName, presence: true,
+                                      format: {
+                                      with: /\A[ぁ-んァ-ヶー一-龠]+\z/,
+                                      message: "は全角で入力してください"
+                                      }
+
 end

--- a/app/views/devise/registrations/new_deliveryAddress.html.haml
+++ b/app/views/devise/registrations/new_deliveryAddress.html.haml
@@ -3,7 +3,7 @@
 
   .registerWrapper
     .registerWrapper__head
-      %h2 発送元・お届け先住所入力
+      %h2 商品お届け先住所入力
     .registerWrapper__content
       = form_for(@deliveryAddress, url: deliveryAddresses_path, method: :post) do |f|
         = render "devise/shared/error_messages", resource: @deliveryAddress

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -171,7 +171,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\.[a-z]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      identification: 本人確認情報
       destination: 送付先住所
       item: 商品
     attributes:
@@ -17,6 +18,12 @@ ja:
         birth_year: 年
         birth_month: 月
         birth_day: 日
+        identification: 本人情報
+      identification:
+        familyName: お名前（姓）
+        firstName: お名前（名）
+        familyNameKana: お名前（せい）
+        firstNameKana: お名前（めい）
       destination: 
         post_code: 郵便番号
         prefecture_code: 都道府県

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,13 +22,13 @@ ja:
       identification:
         familyName: お名前（姓）
         firstName: お名前（名）
-        familyNameKana: お名前（せい）
-        firstNameKana: お名前（めい）
+        familyNameKana: お名前かな（せい）
+        firstNameKana: お名前かな（めい）
       delivery_address: 
         familyName: お名前（姓）
         firstName: お名前（名）
-        familyNameKana: お名前（せい）
-        firstNameKana: お名前（めい）
+        familyNameKana: お名前かな（せい）
+        firstNameKana: お名前かな（めい）
         postCode: 郵便番号
         prefecture_id: 都道府県
         city: 市区町村

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,7 +3,7 @@ ja:
     models:
       user: ユーザー
       identification: 本人確認情報
-      destination: 送付先住所
+      delivery_address: 商品お届け先住所
       item: 商品
     attributes:
       user:
@@ -24,11 +24,15 @@ ja:
         firstName: お名前（名）
         familyNameKana: お名前（せい）
         firstNameKana: お名前（めい）
-      destination: 
-        post_code: 郵便番号
-        prefecture_code: 都道府県
+      delivery_address: 
+        familyName: お名前（姓）
+        firstName: お名前（名）
+        familyNameKana: お名前（せい）
+        firstNameKana: お名前（めい）
+        postCode: 郵便番号
+        prefecture_id: 都道府県
         city: 市区町村
-        house_number: 番地
+        address: 番地
         building: 建物名
         phone_number: 電話
       item:

--- a/spec/factories/delivery_addresses.rb
+++ b/spec/factories/delivery_addresses.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  
+  factory :delivery_address do
+    familyName     {"振間"}
+    firstName      {"太郎"}
+    familyNameKana {"ふりま"}
+    firstNameKana  {"たろう"}
+    postCode       {"1234567"}
+    prefecture_id  {"1"}
+    city           {"渋谷区"}
+    address        {"渋谷町１−１−１"}
+    buildingName   {"渋谷ビル１０F"}
+    telNumber      {"0312345678"}
+  end
+end

--- a/spec/factories/identifications.rb
+++ b/spec/factories/identifications.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  
+  factory :identification do
+    familyName     {"振間"}
+    firstName      {"太郎"}
+    familyNameKana {"ふりま"}
+    firstNameKana  {"たろう"}
+    birthday       {"1989-01-01"}
+  end
+end

--- a/spec/models/delivery_address_spec.rb
+++ b/spec/models/delivery_address_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+describe DeliveryAddress do
+  describe "#create" do
+    
+  it "項目に全て正しく入力されていれば登録できる" do
+    delivery_address = build(:delivery_address)
+    expect(delivery_address).to be_valid
+  end
+
+  it "必須項目のみ入力されていれば登録できる" do
+    delivery_address = build(:delivery_address, buildingName: nil, telNumber: nil)
+    expect(delivery_address).to be_valid
+  end
+
+  it "名字がなければ登録できない" do
+    delivery_address = build(:delivery_address, familyName: nil)
+    delivery_address.valid?
+    expect(delivery_address.errors[:familyName]).to include("を入力してください")
+  end
+
+  it "名前がなければ登録できない" do
+    delivery_address = build(:delivery_address, firstName: nil)
+    delivery_address.valid?
+    expect(delivery_address.errors[:firstName]).to include("を入力してください")
+  end
+
+  it "名字（かな）がなければ登録できない" do
+    delivery_address = build(:delivery_address, familyNameKana: nil)
+    delivery_address.valid?
+    expect(delivery_address.errors[:familyNameKana]).to include("を入力してください")
+  end
+
+  it "名前（かな）がなければ登録できない" do
+    delivery_address = build(:delivery_address, firstName: nil)
+    delivery_address.valid?
+    expect(delivery_address.errors[:firstName]).to include("を入力してください")
+  end
+
+  it "名字（かな）がひらがなでなければ登録できない" do
+    delivery_address = build(:delivery_address, familyNameKana: "振間")
+    delivery_address.valid?
+    expect(delivery_address.errors[:familyNameKana]).to include("はひらがなで入力してください")
+  end
+
+  it "名前（かな）がひらがなでなければ登録できない" do
+    delivery_address = build(:delivery_address, firstNameKana: "太郎")
+    delivery_address.valid?
+    expect(delivery_address.errors[:firstNameKana]).to include("はひらがなで入力してください")
+  end
+
+  it "郵便番号がなければ登録できない" do
+    delivery_address = build(:delivery_address, postCode: nil)
+    delivery_address.valid?
+    expect(delivery_address.errors[:postCode]).to include("を入力してください")
+  end
+
+  it "郵便番号が7文字以外だと登録できない" do
+    delivery_address = build(:delivery_address, postCode: "12345678")
+    delivery_address.valid?
+    expect(delivery_address.errors[:postCode]).to include("は7文字で入力してください")
+  end
+
+  it "郵便番号が7文字だと登録できる" do
+    delivery_address = build(:delivery_address, postCode: "1234567")
+    expect(delivery_address).to be_valid
+  end
+
+  it "都道府県を選択していないと登録できない" do
+    delivery_address = build(:delivery_address, prefecture_id: nil)
+    delivery_address.valid?
+    expect(delivery_address.errors[:prefecture_id]).to include("を入力してください")
+  end
+
+  it "市区町村を選択していないと登録できない" do
+    delivery_address = build(:delivery_address, city: nil)
+    delivery_address.valid?
+    expect(delivery_address.errors[:city]).to include("を入力してください")
+  end
+
+  it "番地を選択していないと登録できない" do
+    delivery_address = build(:delivery_address, address: nil)
+    delivery_address.valid?
+    expect(delivery_address.errors[:address]).to include("を入力してください")
+  end
+  end
+end

--- a/spec/models/identification_spec.rb
+++ b/spec/models/identification_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+describe Identification do
+  describe '#create' do
+    
+  it "必須項目が全て正しく入力されていれば登録できる" do
+    identification = build(:identification)
+    expect(identification).to be_valid
+  end
+
+  end
+end

--- a/spec/models/identification_spec.rb
+++ b/spec/models/identification_spec.rb
@@ -7,5 +7,73 @@ describe Identification do
     expect(identification).to be_valid
   end
 
+  it "名字がなければ登録できない" do
+    identification = build(:identification, familyName: nil)
+    identification.valid?
+    expect(identification.errors[:familyName]).to include("を入力してください")
+  end
+
+  it "名前がなければ登録できない" do
+    identification = build(:identification, firstName: nil)
+    identification.valid?
+    expect(identification.errors[:firstName]).to include("を入力してください")
+  end
+
+  it "名字が全角でなければ登録できない" do
+    identification = build(:identification, familyName: "hurima")
+    identification.valid?
+    expect(identification.errors[:familyName]).to include("は全角で入力してください")
+  end
+
+  it "名前がなければ登録できない" do
+    identification = build(:identification, firstName: "taro")
+    identification.valid?
+    expect(identification.errors[:firstName]).to include("は全角で入力してください")
+  end
+
+  it "名字（かな）がなければ登録できない" do
+    identification = build(:identification, familyNameKana: nil)
+    identification.valid?
+    expect(identification.errors[:familyNameKana]).to include("を入力してください")
+  end
+
+  it "名前（かな）がなければ登録できない" do
+    identification = build(:identification, firstNameKana: nil)
+    identification.valid?
+    expect(identification.errors[:firstNameKana]).to include("を入力してください")
+  end
+
+  it "名字（かな）が全角でなければ登録できない" do
+    identification = build(:identification, familyNameKana: "hurima")
+    identification.valid?
+    expect(identification.errors[:familyNameKana]).to include("は全角ひらがなで入力してください")
+  end
+
+  it "名前（かな）が全角でなければ登録できない" do
+    identification = build(:identification, firstNameKana: "taro")
+    identification.valid?
+    expect(identification.errors[:firstNameKana]).to include("は全角ひらがなで入力してください")
+  end
+
+  it "名字（かな）がひらがなでなければ登録できない" do
+    identification = build(:identification, familyNameKana: "振間")
+    identification.valid?
+    expect(identification.errors[:familyNameKana]).to include("は全角ひらがなで入力してください")
+  end
+
+  it "名前（かな）がひらがなでなければ登録できない" do
+    identification = build(:identification, firstNameKana: "太郎")
+    identification.valid?
+    expect(identification.errors[:firstNameKana]).to include("は全角ひらがなで入力してください")
+  end
+
+
+
+
+
+
+
+
+
   end
 end

--- a/spec/models/identification_spec.rb
+++ b/spec/models/identification_spec.rb
@@ -66,14 +66,5 @@ describe Identification do
     identification.valid?
     expect(identification.errors[:firstNameKana]).to include("は全角ひらがなで入力してください")
   end
-
-
-
-
-
-
-
-
-
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+describe User do
+  describe '#create' do
+
+    it "必須項目が全て正しく入力されていれば登録できる" do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+
+    it "nicknameがなければ登録できない" do
+      user = build(:user, nickname: nil)
+      user.valid?
+      expect(user.errors[:nickname]).to include("を入力してください")
+    end
+
+    it "メールアドレスがなければ登録できない" do
+      user =  build(:user, email: nil)
+      user.valid?
+      expect(user.errors[:email]).to include("が入力されていません。")
+    end
+
+    it "既に登録済みのメールアドレスがある場合は登録できない" do
+      user = create(:user)
+      another_user = build(:user, email: user.email)
+      another_user.valid?
+      expect(another_user.errors[:email]).to include("は既に使用されています。")
+    end
+
+    it "メールアドレスに@とドメインがなければ登録できない" do
+      user = build(:user, email: "testtest")
+      user.valid?
+      expect(user.errors[:email]).to include("は有効でありません。")
+    end
+
+    it "メールアドレスに@があってもドメインがなければ登録できない" do
+      user = build(:user, email: "test@test")
+      user.valid?
+      expect(user.errors[:email]).to include("は有効でありません。")
+    end
+
+    it "メールアドレスにドメインがあっても@がなければ登録できない" do
+      user = build(:user, email: "test.test")
+      user.valid?
+      expect(user.errors[:email]).to include("は有効でありません。")
+    end
+
+    it "メールアドレスに@とドメインがあれば登録できる" do
+      user = build(:user, email: "test@test.test")
+      user.valid?
+      expect(user).to be_valid
+    end
+
+    it "パスワードがなければ登録できない" do
+      user = 
+    end
+
+
+
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ describe User do
       expect(user).to be_valid
     end
 
-    it "nicknameがなければ登録できない" do
+    it "ニックネームがなければ登録できない" do
       user = build(:user, nickname: nil)
       user.valid?
       expect(user.errors[:nickname]).to include("を入力してください")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,15 +46,30 @@ describe User do
 
     it "メールアドレスに@とドメインがあれば登録できる" do
       user = build(:user, email: "test@test.test")
-      user.valid?
       expect(user).to be_valid
     end
 
     it "パスワードがなければ登録できない" do
-      user = 
+      user = build(:user, password: nil)
+      user.valid?
+      expect(user.errors[:password]).to include("が入力されていません。")
     end
 
+    it "パスワードが入力されていても確認用が入力されていないと登録できない" do
+      user = build(:user, password_confirmation: "")
+      user.valid?
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
+    end
 
+    it "パスワードが6文字以下だと登録できない" do
+      user = build(:user, password: "111111", password_confirmation: "11111")
+      user.valid?
+      expect(user.errors[:password]).to include("は7文字以上に設定して下さい。")
+    end
 
+    it "パスワードが7文字以上なら登録できる" do
+      user = build(:user, password: "2222222", password_confirmation: "2222222")
+      expect(user).to be_valid
+    end
   end
 end


### PR DESCRIPTION
#What
ユーザー新規登録関係（Usersテーブル、Identificationsテーブル、deliveryAddressesテーブル）のモデル単体テストを行なった。
まず詳細なバリデーションを設定していなかったので追加をした。次にバリデーションに引っかかった際のエラー文の追記および和訳を行い、その後単体テストを行なった。

#Why
バリデーションに抜けがないか確認するため。