### PR TITLE
商品購入関係のセキュリティー強化

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -57,6 +57,8 @@ class PurchasesController < ApplicationController
     @good.update(buyer_id: current_user.id)
   end
 
+  
+  private
   def login_check
     redirect_to root_path unless user_signed_in?
   end
@@ -76,8 +78,6 @@ class PurchasesController < ApplicationController
       redirect_to root_path
     end
   end
-
-
 
   def set_good
     @good = Good.find(params[:good_id])

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -2,7 +2,7 @@ class PurchasesController < ApplicationController
 
   before_action :login_check
   before_action :own_goods
-  # before_action :sold_out
+  before_action :sold_out
   before_action :set_good, only: [:index, :pay]
   require "payjp"
 
@@ -69,13 +69,13 @@ class PurchasesController < ApplicationController
     end
   end
 
-  # def sold_out
-  #   @good = Good.find(params[:good_id])
-  #   if
-  #     @good.buyer_id.present?
-  #     redirect_to root_path
-  #   end
-  # end
+  def sold_out
+    @good = Good.find(params[:good_id])
+    if
+      @good.buyer_id.present?
+      redirect_to root_path
+    end
+  end
 
 
 

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -57,24 +57,24 @@ class PurchasesController < ApplicationController
     @good.update(buyer_id: current_user.id)
   end
 
-  
+
   private
   def login_check
     redirect_to root_path unless user_signed_in?
   end
 
   def own_goods
-    @good = Good.find(params[:good_id])
+    good = Good.find(params[:good_id])
     if
-      @good.user_id == current_user.id
+      good.user_id == current_user.id
       redirect_to root_path
     end
   end
 
   def sold_out
-    @good = Good.find(params[:good_id])
+    good = Good.find(params[:good_id])
     if
-      @good.buyer_id.present?
+      good.buyer_id.present?
       redirect_to root_path
     end
   end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,5 +1,6 @@
 class PurchasesController < ApplicationController
 
+  before_action :login_check
   before_action :set_good, only: [:index, :pay]
   require "payjp"
 
@@ -50,6 +51,10 @@ class PurchasesController < ApplicationController
   def done
     @good = Good.find(params[:good_id])
     @good.update(buyer_id: current_user.id)
+  end
+
+  def login_check
+    redirect_to root_path unless user_signed_in?
   end
 
   def set_good

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -2,7 +2,7 @@ class PurchasesController < ApplicationController
 
   before_action :login_check
   before_action :own_goods
-  before_action :sold_out
+  # before_action :sold_out
   before_action :set_good, only: [:index, :pay]
   require "payjp"
 
@@ -39,7 +39,7 @@ class PurchasesController < ApplicationController
 
   def pay
     unless
-      @good.user_id == current_user.id
+      @good.user_id == current_user.id || @good.buyer_id.present?
         @card = CreditCard.find_by(user_id: current_user.id)
         Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_PRIVATE_KEY]
 
@@ -69,13 +69,13 @@ class PurchasesController < ApplicationController
     end
   end
 
-  def sold_out
-    @good = Good.find(params[:good_id])
-    if
-      @good.buyer_id.present?
-      redirect_to root_path
-    end
-  end
+  # def sold_out
+  #   @good = Good.find(params[:good_id])
+  #   if
+  #     @good.buyer_id.present?
+  #     redirect_to root_path
+  #   end
+  # end
 
 
 

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -2,6 +2,7 @@ class PurchasesController < ApplicationController
 
   before_action :login_check
   before_action :own_goods
+  before_action :sold_out
   before_action :set_good, only: [:index, :pay]
   require "payjp"
 
@@ -67,6 +68,15 @@ class PurchasesController < ApplicationController
       redirect_to root_path
     end
   end
+
+  def sold_out
+    @good = Good.find(params[:good_id])
+    if
+      @good.buyer_id.present?
+      redirect_to root_path
+    end
+  end
+
 
 
   def set_good

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,6 +1,7 @@
 class PurchasesController < ApplicationController
 
   before_action :login_check
+  before_action :own_goods
   before_action :set_good, only: [:index, :pay]
   require "payjp"
 
@@ -56,6 +57,15 @@ class PurchasesController < ApplicationController
   def login_check
     redirect_to root_path unless user_signed_in?
   end
+
+  def own_goods
+    @good = Good.find(params[:good_id])
+    if
+      @good.user_id == current_user.id
+      redirect_to root_path
+    end
+  end
+
 
   def set_good
     @good = Good.find(params[:good_id])

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -37,16 +37,18 @@ class PurchasesController < ApplicationController
   end
 
   def pay
-    @card = CreditCard.find_by(user_id: current_user.id)
-    Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_PRIVATE_KEY]
+    unless
+      @good.user_id == current_user.id
+        @card = CreditCard.find_by(user_id: current_user.id)
+        Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_PRIVATE_KEY]
 
-    charge = Payjp::Charge.create(
-      amount: @good.price,
-      customer: Payjp::Customer.retrieve(@card.customer_id),
-      currency: 'jpy'
-    )
-    
-    redirect_to action: 'done'
+        charge = Payjp::Charge.create(
+          amount: @good.price,
+          customer: Payjp::Customer.retrieve(@card.customer_id),
+          currency: 'jpy'
+        )
+        redirect_to action: 'done'
+    end
   end
 
   def done

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -25,9 +25,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create_identification
     @user = User.new(session["devise.regist_data"]["user"])
     @identification = Identification.new(identification_params)
-    # if session["identification"].present?
-      # redirect_to root_path
-    # else
     unless @identification.valid?
       flash.now[:alert] = @identification.errors.full_messages
       render :new_identification and return
@@ -36,7 +33,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     session["identification"] = @identification.attributes
     @deliveryAddress = @user.build_deliveryAddress
     render :new_deliveryAddress
-    # end
   end
 
   def create_deliveryAddress

--- a/app/views/goods/index.html.haml
+++ b/app/views/goods/index.html.haml
@@ -91,23 +91,24 @@
       - @goods.each do |good|
         -if good.buyer_id.present?
           .pickupbox__category__list
-            %figure.pickupbox__category__lists--image
-              .goods-box_photo__sold
-                .goods-box_photo__sold__inner
-                  SOLD
-              = image_tag good.pictures[0].goodsImage.url
-            .pickupbox__category__list--text
-              %h3.name 
-                = good.goodsName
-              .syosai
-                %ul
-                  %li<> 
-                    = good.price 
-                    円
-                  %li
-                    %i.fa  
-                    ★0
-                %p.zeikomi (税込)
+            = link_to good_path(good.id) do
+              %figure.pickupbox__category__lists--image
+                .goods-box_photo__sold
+                  .goods-box_photo__sold__inner
+                    SOLD
+                = image_tag good.pictures[0].goodsImage.url
+              .pickupbox__category__list--text
+                %h3.name 
+                  = good.goodsName
+                .syosai
+                  %ul
+                    %li<> 
+                      = good.price 
+                      円
+                    %li
+                      %i.fa  
+                      ★0
+                  %p.zeikomi (税込)
 
         -else
           .pickupbox__category__list
@@ -131,23 +132,24 @@
       - @goods1.each do |good|
         -if good.buyer_id.present?
           .pickupbox__category__list
-            %figure.pickupbox__category__lists--image
-              .goods-box_photo__sold
-                .goods-box_photo__sold__inner
-                  SOLD
-              = image_tag good.pictures[0].goodsImage.url
-            .pickupbox__category__list--text
-              %h3.name 
-                = good.goodsName
-              .syosai
-                %ul
-                  %li<> 
-                    = good.price 
-                    円
-                  %li
-                    %i.fa  
-                    ★0
-                %p.zeikomi (税込)
+            = link_to good_path(good.id) do
+              %figure.pickupbox__category__lists--image
+                .goods-box_photo__sold
+                  .goods-box_photo__sold__inner
+                    SOLD
+                = image_tag good.pictures[0].goodsImage.url
+              .pickupbox__category__list--text
+                %h3.name 
+                  = good.goodsName
+                .syosai
+                  %ul
+                    %li<> 
+                      = good.price 
+                      円
+                    %li
+                      %i.fa  
+                      ★0
+                  %p.zeikomi (税込)
         -else
           .pickupbox__category__list
             = link_to good_path(good.id) do
@@ -170,23 +172,24 @@
       - @goods2.each do |good|
         -if good.buyer_id.present?
           .pickupbox__category__list
-            %figure.pickupbox__category__lists--image
-              .goods-box_photo__sold
-                .goods-box_photo__sold__inner
-                  SOLD
-              = image_tag good.pictures[0].goodsImage.url
-            .pickupbox__category__list--text
-              %h3.name 
-                = good.goodsName
-              .syosai
-                %ul
-                  %li<> 
-                    = good.price 
-                    円
-                  %li
-                    %i.fa  
-                    ★0
-                %p.zeikomi (税込)
+            = link_to good_path(good.id) do
+              %figure.pickupbox__category__lists--image
+                .goods-box_photo__sold
+                  .goods-box_photo__sold__inner
+                    SOLD
+                = image_tag good.pictures[0].goodsImage.url
+              .pickupbox__category__list--text
+                %h3.name 
+                  = good.goodsName
+                .syosai
+                  %ul
+                    %li<> 
+                      = good.price 
+                      円
+                    %li
+                      %i.fa  
+                      ★0
+                  %p.zeikomi (税込)
         -else
           .pickupbox__category__list
             = link_to good_path(good.id) do

--- a/app/views/goods/show.html.haml
+++ b/app/views/goods/show.html.haml
@@ -49,18 +49,28 @@
               %span.spanShippingFee
         .selectPurchace
           .selectPurchace__selectPurchaceMove
-            - if @good.buyer_id.present?
-              %p.selectPurchaceMoveForm
-                売り切れです
-            - else
-              - if user_signed_in?
-                - if current_user.id == @good.user_id
-                  %p.selectPurchaceMoveForm
-                    出品頂いた商品です
-                - elsif current_user.id != @good.user_id
-                  =link_to "購入画面に進む", good_purchases_path(@good)
-              - elsif not user_signed_in?
-                = link_to "ログインして購入へ", new_user_session_path
+            -# - if @good.buyer_id.present?
+            -#   %p.selectPurchaceMoveForm
+            -#     売り切れです
+            -# - else
+            -#   - if user_signed_in?
+            -#     - if current_user.id == @good.user_id
+            -#       %p.selectPurchaceMoveForm
+            -#         出品頂いた商品です
+            -#     - elsif current_user.id != @good.user_id
+            -#       =link_to "購入画面に進む", good_purchases_path(@good)
+            -#   - elsif not user_signed_in?
+            -#     = link_to "ログインして購入へ", new_user_session_path
+
+            - if user_signed_in?
+              - if current_user.id == @good.user_id
+                %p.selectPurchaceMoveForm
+                  出品頂いた商品です
+              - elsif current_user.id != @good.user_id
+                =link_to "購入画面に進む", good_purchases_path(@good)
+            - elsif not user_signed_in?
+              = link_to "ログインして購入へ", new_user_session_path
+
         .selectDescription
           .selectDescription__selectDescriptionBody
             %p.selectDescriptionBodyExplain

--- a/app/views/goods/show.html.haml
+++ b/app/views/goods/show.html.haml
@@ -49,14 +49,18 @@
               %span.spanShippingFee
         .selectPurchace
           .selectPurchace__selectPurchaceMove
-            - if user_signed_in?
-              - if current_user.id == @good.user_id
-                %p.selectPurchaceMoveForm
-                  出品頂いた商品です
-              - elsif current_user.id != @good.user_id
-                =link_to "購入画面に進む", good_purchases_path(@good)
-            - elsif not user_signed_in?
-              = link_to "ログインして購入へ", new_user_session_path
+            - if @good.buyer_id.present?
+              %p.selectPurchaceMoveForm
+                売り切れです
+            - else
+              - if user_signed_in?
+                - if current_user.id == @good.user_id
+                  %p.selectPurchaceMoveForm
+                    出品頂いた商品です
+                - elsif current_user.id != @good.user_id
+                  =link_to "購入画面に進む", good_purchases_path(@good)
+              - elsif not user_signed_in?
+                = link_to "ログインして購入へ", new_user_session_path
         .selectDescription
           .selectDescription__selectDescriptionBody
             %p.selectDescriptionBodyExplain

--- a/app/views/goods/show.html.haml
+++ b/app/views/goods/show.html.haml
@@ -49,27 +49,18 @@
               %span.spanShippingFee
         .selectPurchace
           .selectPurchace__selectPurchaceMove
-            -# - if @good.buyer_id.present?
-            -#   %p.selectPurchaceMoveForm
-            -#     売り切れです
-            -# - else
-            -#   - if user_signed_in?
-            -#     - if current_user.id == @good.user_id
-            -#       %p.selectPurchaceMoveForm
-            -#         出品頂いた商品です
-            -#     - elsif current_user.id != @good.user_id
-            -#       =link_to "購入画面に進む", good_purchases_path(@good)
-            -#   - elsif not user_signed_in?
-            -#     = link_to "ログインして購入へ", new_user_session_path
-
-            - if user_signed_in?
-              - if current_user.id == @good.user_id
-                %p.selectPurchaceMoveForm
-                  出品頂いた商品です
-              - elsif current_user.id != @good.user_id
-                =link_to "購入画面に進む", good_purchases_path(@good)
-            - elsif not user_signed_in?
-              = link_to "ログインして購入へ", new_user_session_path
+            - if @good.buyer_id.present?
+              %p.selectPurchaceMoveForm
+                売り切れです
+            - else
+              - if user_signed_in?
+                - if current_user.id == @good.user_id
+                  %p.selectPurchaceMoveForm
+                    出品頂いた商品です
+                - elsif current_user.id != @good.user_id
+                  =link_to "購入画面に進む", good_purchases_path(@good)
+              - elsif not user_signed_in?
+                = link_to "ログインして購入へ", new_user_session_path
 
         .selectDescription
           .selectDescription__selectDescriptionBody

--- a/app/views/purchases/index.html.haml
+++ b/app/views/purchases/index.html.haml
@@ -90,6 +90,4 @@
         .purchasesIndex__contents--button--message
           クレジットカードが登録されていません
 
-
-
   = render partial: 'modules/footerSub'


### PR DESCRIPTION
#What
チェックリストを参考にセキュリティー強化を行なった。冒頭（）内の数字はチェックリストの対応番号。
（１、３、６）ログインしていないユーザーまたは、自身が出品した商品及び売り切れ後の、商品購入ページへの直打ちでの侵入に対する対応はbefore_actionでトップページ戻るよう設定した。
（４、７）購入機能に必要なpayアクションは、unlessメソッドを使用し、自身の商品でもなく売り切れでもなければ作動するように設定した。
（５）購入された商品は”売り切れです”の表示にした。
（おまけ）売り切れ後も商品詳細を閲覧できるように編集した。

#Why
アプリ運営でセキュリティー管理は重要なので。